### PR TITLE
Fallback to ip if backend dns does not resolve

### DIFF
--- a/lib/kontena/backend_resolver.rb
+++ b/lib/kontena/backend_resolver.rb
@@ -50,6 +50,8 @@ module Kontena
       resolved = dns_resolver.resolve(dns_name)
       if resolved.is_a?(Resolv::IPv4)
         [resolved]
+      elsif resolved.nil?
+        [dns_name]
       else
         resolved
       end

--- a/spec/kontena/backend_resolver_spec.rb
+++ b/spec/kontena/backend_resolver_spec.rb
@@ -56,5 +56,10 @@ describe Kontena::BackendResolver do
       ips = subject.resolve_dns('www.google.com')
       expect(ips.size).to be > 1
     end
+
+    it 'returns passed value if dns does not resolve' do
+      ips = subject.resolve_dns('10.1.1.1')
+      expect(ips[0]).to eq('10.1.1.1')
+    end
   end
 end


### PR DESCRIPTION
Allows to set backends as ip's.