### PR TITLE
Upgraded LetsEncrypt TOS and acmetool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER Kontena, Inc. <info@kontena.io>
 
-ENV BACKENDS=kontena-server-api:9292 ACMETOOL_VERSION=0.0.54
+ENV BACKENDS=kontena-server-api:9292 ACMETOOL_VERSION=0.0.61
 
 RUN echo 'deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x80f70e11f0f0d5f10cb20e62f5da5f09c3173aa6 && \

--- a/acmetool/response-file.yml
+++ b/acmetool/response-file.yml
@@ -1,2 +1,2 @@
-"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf": true
+"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf": true
 "acmetool-quickstart-choose-method": proxy


### PR DESCRIPTION
Turns out LetsEncrypt has recently (Nov, 15th) rolled out an upgrade for Terms Of Service, therefore "acme-agreement" must be updated accordingly.

Also, seems that new builds of "acmetool" are out in the wild and therefore an upgrade.

Both changes have been put through validations on TravisCI, here you can find build/test results: https://travis-ci.org/ptsurbeleu/kontena-haproxy/builds/310398587.