### PR TITLE
Add SERVER_OPTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ HAProxy image that does load-balancing between configured addresses. HAProxy rec
 | BALANCE              | roundrobin | Load balancing algorithm to use. Possible values include: roundrobin, static-rr, source, leastconn. |
 | MAXCONN              | 4096 | Sets the maximum per-process number of concurrent connections. |
 | OPTION              | redispatch, forwardfor | Extra options (comma separated list). |
+| SERVER_OPTION        |        | Extra options for servers. For example, `ssl verify none` for an HTTPS backend. |
 | TIMEOUT              | connect 5000, client 50000, server 50000 | Connect options. |
 | POLLING_INTERVAL     | 10 | How often backend addresses are polled (resolved). |
 | VIRTUAL_HOSTS        |        | Comma separated list of virtual_host=backend mappings, for example app1=www.domain.com,app2=www.bar.com |

--- a/bin/kontena-haproxy
+++ b/bin/kontena-haproxy
@@ -8,6 +8,7 @@ mode = ENV['MODE'] || 'http'
 balance = ENV['BALANCE'] || 'roundrobin'
 maxconn = ENV['MAXCONN'] || '4096'
 option = (ENV['OPTION'] || 'redispatch, forwardfor').split(',')
+server_option = ENV['SERVER_OPTION'] || ''
 timeout = (ENV['TIMEOUT'] || 'connect 5000, client 50000, server 50000').split(',')
 polling_interval = (ENV['POLLING_INTERVAL'] || '10').to_i
 virtual_hosts = ENV['VIRTUAL_HOSTS'] || ''
@@ -25,6 +26,7 @@ config_generator_supervisor = Kontena::HaproxyConfigGenerator.supervise(
   mode: mode,
   balance: balance,
   option: option,
+  server_option: server_option,
   timeout: timeout,
   polling_interval: polling_interval,
   virtual_hosts: virtual_hosts

--- a/lib/kontena/haproxy_config_generator.rb
+++ b/lib/kontena/haproxy_config_generator.rb
@@ -95,7 +95,7 @@ module Kontena
           service_name = service.gsub('.', '-')
           i = 1
           backend_services[service].each do |host|
-            backend << 'server %s %s:%s' % ["#{service_name}-#{i}", host[:ip], host[:port]]
+            backend << ['server', "#{service_name}-#{i}", "#{host[:ip]}:#{host[:port]}", options[:server_option]].reject(&:empty?).join(' ')
             i += 1
           end
           id = service.downcase.sub('-', '_')
@@ -113,7 +113,7 @@ module Kontena
         service_name = service.gsub('.', '-')
         i = 1
         hosts.each do |host|
-          backend << 'server %s %s:%s' % ["#{service_name}-#{i}", host[:ip], host[:port]]
+            backend << ['server', "#{service_name}-#{i}", "#{host[:ip]}:#{host[:port]}", options[:server_option]].reject(&:empty?).join(' ')
           i += 1
         end
       end

--- a/spec/kontena/haproxy_config_generator_spec.rb
+++ b/spec/kontena/haproxy_config_generator_spec.rb
@@ -14,6 +14,7 @@ describe Kontena::HaproxyConfigGenerator do
       polling_interval: 5,
       virtual_hosts: 'ghost=blog.kontena.io,jenkins=ci.kontena.io',
       option: %w{ redispatch forwardfor},
+      server_option: '',
       timeout: ['connect 5000', 'client 50000', 'server 50000']
     ).wrapped_object
   end


### PR DESCRIPTION
SERVER_OPTION parameter allows the user to add server-level options into generated haproxy configuration.

For example, setting SERVER_OPTIONS to `ssl verify none` allows HTTPS backends without setting up any certificates.