### PR TITLE
Fake syslog with socat and dump to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN echo 'deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main' >> 
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 
-RUN apt-get install -y haproxy ruby2.2 ruby2.2-dev build-essential ca-certificates libssl-dev curl && \
+RUN apt-get install -y haproxy ruby2.2 ruby2.2-dev build-essential ca-certificates libssl-dev curl socat && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     gem install bundler && \

--- a/lib/kontena/haproxy_config_generator.rb
+++ b/lib/kontena/haproxy_config_generator.rb
@@ -16,6 +16,7 @@ module Kontena
 
     def create_default_config
       config['global'] = [
+        "log /dev/log local1 info",
         "maxconn %s" % options[:maxconn],
         "pidfile /var/run/haproxy.pid",
         "user haproxy",
@@ -24,7 +25,9 @@ module Kontena
         "stats socket /var/run/haproxy.stats level admin"
       ]
       config['defaults'] = [
-        "mode %s" % options[:mode]
+        "mode %s" % options[:mode],
+        "log global",
+        "option httplog"
       ]
       if options[:option]
         options[:option].each do |option|

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,9 @@ export RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.1
 export RUBY_GC_MALLOC_LIMIT=16000100
 export RUBY_GC_OLDMALLOC_LIMIT_MAX=16000100
 
+# fake syslog
+socat UNIX-RECV:/dev/log,mode=666 STDOUT &
+
 if [ "${VIRTUAL_HOST}" = "**None**" ]; then
     unset VIRTUAL_HOST
 fi


### PR DESCRIPTION
Slightly hackish, but haproxy does not really support any other logging than to syslog. So `socat` "fakes" the syslog and just dumps what it gets into stdout.

Here's how the logs looks with this in:
```
I, [2018-05-18T18:29:45.977586 #1]  INFO -- : Starting HAProxy process
<141>May 18 18:29:45 haproxy[21]: Proxy default_frontend started.
<141>May 18 18:29:45 haproxy[21]: Proxy default_backend started.
<141>May 18 18:29:45 haproxy[21]: Proxy acme started.
<142>May 18 18:29:52 haproxy[21]: 172.17.0.1:37144 [18/May/2018:18:29:52.708] default_frontend default_backend/google-fi-1 0/0/11/24/35 301 538 - - ---- 1/1/0/1/0 0/0 "GET / HTTP/1.1"
```

Yes, there's some "noise" from syslog format but I think it's something we could live with for now.

ping @nevalla @jakolehm 
